### PR TITLE
Add support for KA9Q Radio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ user.cfg
 # cmake
 build
 
+
+venv/
+__pycache__/*
+*.pyc
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-FROM debian:bullseye as builder
-MAINTAINER sa2kng <knegge@gmail.com>
+FROM debian:bookworm-slim AS builder
+LABEL org.opencontainers.image.authors="sa2kng <knegge@gmail.com>"
 
-RUN apt-get -y update && apt -y upgrade && apt-get -y install --no-install-recommends \
-    cmake \
-    build-essential \
-    ca-certificates \
-    git \
-    libusb-1.0-0-dev \
-    libatlas-base-dev \
-    libsoapysdr-dev \
-    soapysdr-module-all &&\
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install --no-install-recommends \
+    cmake build-essential ca-certificates git libusb-1.0-0-dev \
+    libatlas-base-dev libsoapysdr-dev soapysdr-module-all \
+    libairspy-dev libairspyhf-dev libavahi-client-dev libbsd-dev \
+    libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev \
+    libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev \
+    portaudio19-dev libasound2-dev libogg-dev uuid-dev rsync && \
     rm -rf /var/lib/apt/lists/*
 
 # install everything in /target and it will go in to / on destination image. symlink make it easier for builds to find files installed by this.
@@ -26,13 +24,25 @@ RUN git clone --depth 1 https://github.com/rxseger/rx_tools.git &&\
     cmake -B build -DCMAKE_INSTALL_PREFIX=/target/usr -DCMAKE_BUILD_TYPE=Release &&\
     cmake --build build --target install
 
+# Compile and install pcmcat and tune from KA9Q-Radio
+RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
+  cd /root/ka9q-radio && \
+  git checkout 4025a34db6e88dce87b8f67c7eb9cc339b920261 && \
+  make \
+    -f Makefile.linux \
+    pcmrecord tune && \
+  mkdir -p /target/usr/bin/ && \
+  cp pcmrecord /target/usr/bin/ && \
+  cp tune /target/usr/bin/ && \
+  rm -rf /root/ka9q-radio
+
 COPY scripts/* /target/usr/bin/
 
 # to support arm wheels
-RUN echo '[global]\nextra-index-url=https://www.piwheels.org/simple' > /target/etc/pip.conf
+# RUN echo '[global]\nextra-index-url=https://www.piwheels.org/simple' > /target/etc/pip.conf
 
-FROM debian:bullseye as prod
-RUN apt-get -y update && apt -y upgrade && apt-get -y install --no-install-recommends \
+FROM debian:bookworm-slim AS prod
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install --no-install-recommends \
     libusb-1.0-0 \
     python3-venv \
     python3-crcmod \
@@ -44,10 +54,15 @@ RUN apt-get -y update && apt -y upgrade && apt-get -y install --no-install-recom
     bc \
     rtl-sdr \
     libatlas3-base \
+    avahi-utils \
+    libnss-mdns \
+    libbsd0 \
     soapysdr-module-all &&\
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --system --no-cache-dir --prefer-binary horusdemodlib
+RUN pip install --break-system-packages --no-cache-dir --prefer-binary horusdemodlib
+
+RUN sed -i -e 's/files dns/files mdns4_minimal [NOTFOUND=return] dns/g' /etc/nsswitch.conf
 
 COPY --from=builder /target /
 CMD ["bash"]

--- a/scripts/docker_ka9q_single.sh
+++ b/scripts/docker_ka9q_single.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+#	Horus Binary KA9Q-Radio Helper Script
+#
+#   Uses ka9q-radio (pcmrecord) to receive a chunk of spectrum, and passes it into horus_demod.
+#
+
+# Calculate the frequency estimator limits
+FSK_LOWER=$(echo "$RXBANDWIDTH / -2" | bc)
+FSK_UPPER=$(echo "$RXBANDWIDTH / 2" | bc)
+
+SSRC=$(($RXFREQ / 1000))01
+RADIO=$(echo $SDR_DEVICE | sed 's/-pcm//g')
+
+echo "Using SDR Centre Frequency: $RXFREQ Hz"
+echo "Using SSRC: $SSRC"
+echo "Using PCM stream: $SDR_DEVICE"
+echo "Using FSK estimation range: $FSK_LOWER - $FSK_UPPER Hz"
+
+cleanup () {
+    echo "Closing channel $SSRC at frequency $RXFREQ"
+    tune --samprate 48000 --mode iq --low $FSK_LOWER --high $FSK_UPPER --frequency 0 --ssrc $SSRC --radio $RADIO
+}
+
+trap cleanup EXIT
+
+# Start the receive chain.
+# Note that we now pass in the SDR centre frequency ($RXFREQ) and 'target' signal frequency ($RXFREQ)
+# to enable providing additional metadata to Habitat / Sondehub.
+timeout 5 tune --samprate 48000 --mode iq --low $FSK_LOWER --high $FSK_UPPER --frequency $RXFREQ --ssrc $SSRC --radio $RADIO
+pcmrecord --ssrc $SSRC --catmode --raw $SDR_DEVICE | $DECODER -q --stats=5 -g -m binary --fsk_lower=$FSK_LOWER --fsk_upper=$FSK_UPPER - - | python3 -m horusdemodlib.uploader --freq_hz $RXFREQ --freq_target_hz $RXFREQ $@


### PR DESCRIPTION
This PR adds a KA9Q-Radio launcher script that can be called from Docker.

Using Docker Compose, this YAML snippet will initialize a single decoder:

```
  horus-432630:
    image: ghcr.io/projecthorus/horusdemodlib
    #image: horusdemodlib
    restart: 'always'
    environment:
      # Change this to match the PCM device defined in 
      SDR_DEVICE: rtl-sdr-pcm.local
      STATS_OUTPUT: 0
      DECODER: horus_demod
      DEMODSCRIPT: "docker_ka9q_single.sh"
      # Receive *centre* frequency, in Hz
      # Note: The SDR will be tuned to RXBANDWIDTH/2 below this frequency.
      RXFREQ: 432630000
      # Frequency estimator bandwidth. The wider the bandwidth, the more drift and frequency error the modem can tolerate,
      # but the higher the chance that the modem will lock on to a strong spurious signal.
      # Note: The SDR will be tuned to RXFREQ-RXBANDWIDTH/2, and the estimator set to look at 0-RXBANDWIDTH Hz. (RTL-SDR only)
      RXBANDWIDTH: 10000
    command: 'bash -c $${DEMODSCRIPT}'
    volumes:
      - type: 'tmpfs'
        target: '/tmp'
      - type: 'bind'
        source: './horusdemodlib/user.cfg'
        target: '/user.cfg'
      - type: 'bind'
        source: '/var/run/avahi-daemon/socket'
        target: '/var/run/avahi-daemon/socket'
    network_mode: 'host'
```