### PR TITLE
Allow setting the sample rate

### DIFF
--- a/src/horus_api.c
+++ b/src/horus_api.c
@@ -117,7 +117,7 @@ struct horus *horus_open (int mode) {
 }
 
 struct horus *horus_open_advanced (int mode, int Rs, int tx_tone_spacing) {
-    return horus_open_advanced_sample_rate(mode, Rs, tx_tone_spacing, 48000, 8);
+    return horus_open_advanced_sample_rate(mode, Rs, tx_tone_spacing, 48000, FSK_DEFAULT_P);
 }
 
 struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spacing, int Fs, int P) {

--- a/src/horus_api.c
+++ b/src/horus_api.c
@@ -117,10 +117,10 @@ struct horus *horus_open (int mode) {
 }
 
 struct horus *horus_open_advanced (int mode, int Rs, int tx_tone_spacing) {
-    return horus_open_advanced_sample_rate(mode, Rs, tx_tone_spacing, 48000);
+    return horus_open_advanced_sample_rate(mode, Rs, tx_tone_spacing, 48000, 8);
 }
 
-struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spacing, int Fs) {
+struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spacing, int Fs, int P) {
     int i, mask;
     assert((mode == HORUS_MODE_RTTY_7N1) || (mode == HORUS_MODE_RTTY_7N2) || (mode == HORUS_MODE_RTTY_8N2) || (mode == HORUS_MODE_BINARY_V1) );// || (mode == HORUS_MODE_BINARY_V2_256BIT) || (mode == HORUS_MODE_BINARY_V2_128BIT));
 
@@ -306,7 +306,7 @@ struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spa
 
     // Create the FSK modedm struct. Note that the low-tone-frequency parameter is unused.
     #define UNUSED 1000
-    hstates->fsk = fsk_create(hstates->Fs, hstates->Rs, hstates->mFSK, UNUSED, tx_tone_spacing);
+    hstates->fsk = fsk_create_hbr(hstates->Fs, hstates->Rs, hstates->mFSK, P, FSK_DEFAULT_NSYM, UNUSED, tx_tone_spacing);
 
     // Set/disable the mask estimator depending on if tx_tone_spacing was provided (refer above)
     fsk_set_freq_est_alg(hstates->fsk, mask);

--- a/src/horus_api.c
+++ b/src/horus_api.c
@@ -116,15 +116,18 @@ struct horus *horus_open (int mode) {
     return horus_open_advanced(HORUS_MODE_BINARY_V1, HORUS_BINARY_V1_DEFAULT_BAUD, -1);
 }
 
-
 struct horus *horus_open_advanced (int mode, int Rs, int tx_tone_spacing) {
+    return horus_open_advanced_sample_rate(mode, Rs, tx_tone_spacing, 48000);
+}
+
+struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spacing, int Fs) {
     int i, mask;
     assert((mode == HORUS_MODE_RTTY_7N1) || (mode == HORUS_MODE_RTTY_7N2) || (mode == HORUS_MODE_RTTY_8N2) || (mode == HORUS_MODE_BINARY_V1) );// || (mode == HORUS_MODE_BINARY_V2_256BIT) || (mode == HORUS_MODE_BINARY_V2_128BIT));
 
     struct horus *hstates = (struct horus *)malloc(sizeof(struct horus));
     assert(hstates != NULL);
 
-    hstates->Fs = 48000; hstates->Rs = Rs; hstates->verbose = 0; hstates->mode = mode;
+    hstates->Fs = Fs; hstates->Rs = Rs; hstates->verbose = 0; hstates->mode = mode;
 
     if (mode == HORUS_MODE_RTTY_7N1) {
         // Parameter setup for RTTY 7N2 Reception

--- a/src/horus_api.h
+++ b/src/horus_api.h
@@ -117,9 +117,10 @@ struct horus *horus_open_advanced (int mode, int Rs, int tx_tone_spacing);
  * int Rs - Symbol Rate (Hz). Set to -1 to use the default value for the mode (refer above)
  * int tx_tone_spacing - FSK Tone Spacing, to configure mask estimator. Set to -1 to disable mask estimator.
  * int Fs - Sample rate
+ * int P - Oversamplig rate. (Fs/Rs)%P should equal 0 other the modem will be sad.
  */
 
- struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spacing, int Fs);
+ struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spacing, int Fs, int P);
 
 
 /*

--- a/src/horus_api.h
+++ b/src/horus_api.h
@@ -111,6 +111,18 @@ struct horus *horus_open  (int mode);
 struct horus *horus_open_advanced (int mode, int Rs, int tx_tone_spacing);
 
 /*
+ * Create an Horus Demod config/state struct with more customizations.
+ * 
+ * int mode - Horus Mode Type (refer list above)
+ * int Rs - Symbol Rate (Hz). Set to -1 to use the default value for the mode (refer above)
+ * int tx_tone_spacing - FSK Tone Spacing, to configure mask estimator. Set to -1 to disable mask estimator.
+ * int Fs - Sample rate
+ */
+
+ struct horus *horus_open_advanced_sample_rate (int mode, int Rs, int tx_tone_spacing, int Fs);
+
+
+/*
  * Close a Horus demodulator struct and free memory.
  */
 void          horus_close (struct horus *hstates);


### PR DESCRIPTION
This should be entirely backwards compatible change. I'm not sure what performance impact there is on the modem or issues (I assume it might be a problem because not divisible by 8000?). Can't be any worse than audioop right?

Have tested in webhorus and its able to decode packets