### PR TITLE
add StratoScience custom fields

### DIFF
--- a/custom_field_list.json
+++ b/custom_field_list.json
@@ -292,5 +292,17 @@
         ["rp_xtal_code", "none"],
         ["rp_lu", "none"]
     ]
+},
+"StratoScience": {
+    "comment": "Telemetry for StratoScience 25",
+    "struct": "<hhbbHB",
+    "fields": [
+        ["rot_x", "none"],
+        ["rot_y", "none"],
+        ["acc_x", "divide_by_100"],
+        ["acc_y", "divide_by_100"],
+        ["ext_pressure", "divide_by_10"],
+        ["ext_humidity", "none"]
+    ]
 }
 }


### PR DESCRIPTION
Adds telemetry for StratoScience 2025.
Contains a gyroscopic experiment transmitting Rotation X, Rotation Y, Acceleration X, and Acceleration Y through the Tiny4FSK inputs (over I2C).

Thanks!
-Max Kendall, W0MXX