### PR TITLE
Added "other_calls" parameter handling.

### DIFF
--- a/custom_field_list.json
+++ b/custom_field_list.json
@@ -305,15 +305,16 @@
         ["ext_humidity", "none"]
     ]
 },
-"SP2ZIE": {
-    "comment": "Custom fields for M20",
-    "struct": "<hhBHH",
+"SQ2IPS": {
+    "comment": "Default custom fields for M20",
+    "other_calls": ["SP2ZIE"],
+    "struct": "<hhBHBx",
     "fields": [
         ["ascent_rate", "divide_by_100"],
         ["ext_temperature", "divide_by_10"],
         ["ext_humidity", "none"],
         ["ext_pressure", "divide_by_10"],
-	["payload_voltage", "divide_by_100"]
+	    ["gps_restart_count", "none"]
     ]
 },
 "K5PRK": {

--- a/horusdemodlib/payloads.py
+++ b/horusdemodlib/payloads.py
@@ -210,6 +210,18 @@ def read_custom_field_list(filename="custom_field_list.json"):
                             "fields": _data["fields"]
                         }
                         logging.debug(f"Loaded custom field data for {_payload}.")
+
+                        # other_calls flag for applying custom fields to multiple payloads
+                        if "other_calls" in _data:
+                            for _other_payload in _data["other_calls"]:
+                                if _other_payload in _custom_field_list:
+                                    logging.warning(f"Custom field data for {_other_payload} is already loaded, overwriting.")
+                                _custom_field_list[_other_payload] = {
+                                    "struct": _data["struct"],
+                                    "fields": _data["fields"]
+                                }
+                            logging.debug(f"Loaded custom field data for other calls: {_data["other_calls"]}.")
+
                     else:
                         logging.error(f"Struct field for {_payload} has incorrect length ({_structsize}).")
                         


### PR DESCRIPTION
Added "other_calls" parameter in custom field list as suggested in #269. Tested with a M20 transmitter and `start_rtlsdr.sh` script with 2 calls SQ2IPS and SP2ZIE. When a field is already present it shows a warning and overwrites it.

This feature will be be very useful for our M20 firmware project where all the transmitters will have a different custom fields than then default RS41ng ones.